### PR TITLE
Set default permissions for workflow and pin actions to commit shas.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,6 +3,12 @@ name: "Continuous Integration"
 on:
   workflow_call:
 
+permissions:
+  actions: write
+  checks: write
+  contents: read
+  statuses: write
+
 jobs:
   matrix:
     name: Generate job matrix
@@ -12,7 +18,7 @@ jobs:
     steps:
       - name: Gather CI configuration
         id: matrix
-        uses: laminas/laminas-ci-matrix-action@v1
+        uses: laminas/laminas-ci-matrix-action@6383012fc66934b529727af575aa783bd82a4c03 # 1.33.0
 
   qa:
     name: QA Checks
@@ -23,6 +29,6 @@ jobs:
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
     steps:
       - name: ${{ matrix.name }}
-        uses: laminas/laminas-continuous-integration-action@v1
+        uses: laminas/laminas-continuous-integration-action@07bce265971b2d19f607e47adbb3c04a913145ec # 1.45.0
         with:
           job: ${{ matrix.job }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>laminas/.github:renovate-config"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "local>laminas/.github:renovate-config"
+    ]
 }


### PR DESCRIPTION
Also enables renovate to keep actions commit shas up-to-date
