### PR TITLE
Bump the ci action to 1.46.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,6 @@ jobs:
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
     steps:
       - name: ${{ matrix.name }}
-        uses: laminas/laminas-continuous-integration-action@07bce265971b2d19f607e47adbb3c04a913145ec # 1.45.0
+        uses: laminas/laminas-continuous-integration-action@757a62736b25b11240101d3c616fff4cbc707cfd # 1.46.0
         with:
           job: ${{ matrix.job }}


### PR DESCRIPTION
For some reason, Renovate is not picking this up even with manual rescans.

We don't appear to have a cool-down set on the global config, unless Renovate sets one by default (?)

This _should_ fix the many CI failures we're getting when installing extensions